### PR TITLE
Add env.add(pack.to.Module) macro sugar

### DIFF
--- a/interpret/Env.hx
+++ b/interpret/Env.hx
@@ -82,6 +82,14 @@ class Env {
 
     } //addDefaultModules
 
+    /** Helper to simplify usual addModule() calls */
+    public macro function add(ethis, typePath:haxe.macro.Expr):haxe.macro.Expr {
+        return macro $ethis.addModule(
+            $v{haxe.macro.ExprTools.toString(typePath)},
+            interpret.DynamicModule.fromStatic($typePath)
+        );
+    }
+
     /** Add dynamic module */
     public function addModule(typePath:String, module:DynamicModule):Void {
 


### PR DESCRIPTION
I'm too lazy x)

I added `env.add(pack.to.Module)` macro that simply resolves to `env.addModule('pack.to.Module', interpret.DynamicModule.fromStatic(pack.to.Module))` to be able to skip some boilerplate.